### PR TITLE
Add `no_clobber` option

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ OPTIONS:
     -h, --help
             Output this usage information and exit.
 
+    -n, --no-clobber
+            Do not overwrite an existing file.
+
     -V, --version
             Output version information and exit."
 );
@@ -24,13 +27,16 @@ OPTIONS:
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
-    let args: Box<_> = env::args().skip(1).collect();
-    for arg in args.iter() {
-        match arg.as_str() {
-            "-h" | "--help" => fatal(HELP),
-            "-V" | "--version" => fatal(VERSION),
-            _ => {}
-        }
-    }
-    process::exit(fcp(&args) as i32);
+    let mut args: Vec<String> = env::args().skip(1).collect();
+    let mut no_clobber = false;
+    args.retain(|arg| match arg.as_str() {
+        "-h" | "--help" => fatal(HELP),
+        "-n" | "--no-clobber" => {
+            no_clobber = true;
+            false
+        },
+        "-V" | "--version" => fatal(VERSION),
+        _ => true,
+    });
+    process::exit(fcp(&args, no_clobber) as i32);
 }


### PR DESCRIPTION
This commit adds a new boolean parameter `no_clobber` (https://github.com/Svetlitski/fcp/issues/31#issuecomment-1053722797) to the `copy_file` and `copy_into` functions in order to provide an option to skip copying files that already exist in the destination directory. If `no_clobber` is true and the destination file already exists, an error message is printed and the file is skipped.

The `copy_directory` and `copy_single` functions were updated to pass the `no_clobber` parameter to `copy_file` and `copy_into` respectively.

This change makes the copying process more efficient by avoiding unnecessary copies and also prevents accidental overwriting of existing files.