### PR TITLE
Fix copy 0o500's not empty dir into another dir failed

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -6,8 +6,8 @@ use crate::error::{Error, Result};
 use nix::sys::stat::Mode;
 use nix::unistd;
 use std::convert::TryInto;
-use std::fs::{self, DirBuilder, DirEntry, File, Metadata, OpenOptions, Permissions, ReadDir};
-use std::os::unix::fs::{self as unix, DirBuilderExt, FileTypeExt, OpenOptionsExt, PermissionsExt};
+use std::fs::{self, DirEntry, File, Metadata, OpenOptions, Permissions, ReadDir};
+use std::os::unix::fs::{self as unix, FileTypeExt, OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 
 macro_rules! wrap {
@@ -38,6 +38,7 @@ wrap!(fs, remove_dir_all, ());
 wrap!(fs, remove_file, ());
 wrap!(fs, canonicalize, PathBuf);
 wrap!(fs, create_dir_all, ());
+wrap!(fs, create_dir, ());
 wrap!(File, open, File);
 wrap2!(symlink, unix, ());
 wrap2!(copy, fs, u64);
@@ -53,14 +54,6 @@ pub fn entry_file_type(entry: &DirEntry) -> Result<FileType> {
         Err(err) => Err(Error::new(format!("{}: {}", entry.path().display(), err))),
         Ok(file_type) => Ok(FileType::from(file_type)),
     }
-}
-
-pub fn create_dir<P: AsRef<Path>>(path: P, mode: u32) -> Result<()> {
-    let path = path.as_ref();
-    DirBuilder::new()
-        .mode(mode)
-        .create(path)
-        .map_err(make_error_message!(path))
 }
 
 pub fn create<P: AsRef<Path>>(path: P, mode: u32) -> Result<File> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;
 use std::fmt::Display;
-use std::fs::Metadata;
+use std::fs::{set_permissions, Metadata};
 use std::io;
 use std::ops::BitOr;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
@@ -60,7 +60,7 @@ fn copy_file(source: &Path, source_type: Result<FileType>, dest: &Path) -> bool 
 }
 
 fn copy_directory(source: &Path, dest: &Path) -> Result<bool> {
-    fs::create_dir(dest, fs::symlink_metadata(source)?.permissions().mode())?;
+    fs::create_dir(dest)?;
     let (mut entries, mut has_err) = (Vec::new(), false);
     for entry in fs::read_dir(source)? {
         match entry {
@@ -72,12 +72,15 @@ fn copy_directory(source: &Path, dest: &Path) -> Result<bool> {
         }
     }
     entries.shrink_to_fit();
-    Ok(entries
+    let resutl = entries
         .into_par_iter()
         .map(|(file_name, file_type)| {
             copy_file(&source.join(&file_name), file_type, &dest.join(&file_name))
         })
-        .reduce(|| has_err, BitOr::bitor))
+        .reduce(|| has_err, BitOr::bitor);
+    let _ = set_permissions(dest, fs::symlink_metadata(source)?.permissions())
+        .map_err(|err| Error::new(format!("{}: {}", <Path as AsRef<Path>>::as_ref(dest).display(), err)));
+    Ok(resutl)
 }
 
 fn reject_self_copies(sources: &[PathBuf], dest: &Path) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ OPTIONS:
 static VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn main() {
-    let args: Box<_> = env::args().skip(1).collect();
+    let args: Box<_> = Box::new(env::args().skip(1).collect::<Vec<_>>());
     for arg in args.iter() {
         match arg.as_str() {
             "-h" | "--help" => fatal(HELP),
@@ -33,4 +33,12 @@ fn main() {
         }
     }
     process::exit(fcp(&args) as i32);
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn test() {
+
+    }
 }


### PR DESCRIPTION
fcp failed
```shell
mkdir sa/d
touch sa/f sa/d/f
chmod -R 500 sa
fcp sa da # da dir is not exist now
```
it will failed
